### PR TITLE
Require the byte compiler.

### DIFF
--- a/names.el
+++ b/names.el
@@ -39,6 +39,7 @@
 
 (require 'cl-lib)
 (require 'edebug)
+(require 'bytecomp)
 
 ;;; Support
 (declare-function names--autoload-do-load "names" 2)


### PR DESCRIPTION
I don't know why Emacs doesn't generate a warning about this. However,
when trying to use a names project starting with `emacs -q`, I saw
an error as a result of this being missing.
