### PR TITLE
Add support for rx

### DIFF
--- a/names.el
+++ b/names.el
@@ -1313,5 +1313,14 @@ If STAR is non-nil, parse as a `let*'."
             (mapcar 'names-convert-form (cdr x))))
     (cddr (cdr form)))))
 
+(defun names--convert-rx-define (form &rest args)
+  (apply (if (cdddr form)
+             #'names--convert-defun
+           #'names--convert-defvar)
+         form
+         args))
+(defalias 'names--convert-rx-let 'names--convert-let)
+(defalias 'names--convert-rx-let-eval 'names--convert-let)
+
 (provide 'names)
 ;;; names.el ends here


### PR DESCRIPTION
This is necessary because `rx` does not define edebug specs, and it seems that defining one for it using `def-edebug-spec` does not work either.

The format is described in [(elisp)Extending Rx](https://www.gnu.org/software/emacs/manual/html_node/elisp/Extending-Rx.html)